### PR TITLE
Add workflow step to publish image to Docker Hub

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@master
+    - name: Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: aptible/github-action-demo
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
       - uses: actions/checkout@v2
       - uses: aptible/aptible-deploy-action@v1
         with:


### PR DESCRIPTION
Adds an existing step to publish our image to Docker hub.

I added the appropriate secrets to our repo to enable this to push using
the Deploy bot.