### PR TITLE
A more advanced example.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,26 +4,40 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
-      with:
-        name: aptible/github-action-demo
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Check out code
+        uses: actions/checkout@master
+
+      - name: Publish to Registry
+        id: publish_image
+        uses: elgohr/Publish-Docker-Github-Action@v5
+        with:
+          name: aptible/github-action-demo
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+    outputs:
+      image: aptible/github-action-demo:${{ steps.publish_image.outputs.tag }}
+
   deploy:
+    needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: aptible/aptible-deploy-action@v1
+      - name: Check out code
+        uses: actions/checkout@master
+
+      - name: Deploy to Aptible
+        uses: aptible/aptible-deploy-action@fix-versioned-release
         with:
           username: ${{secrets.APTIBLE_ROBOT_USERNAME}}
           password: ${{secrets.APTIBLE_ROBOOT_PASSWORD}}
-          app: "deploy-action-demo"
-          environment: "chaos"
-          docker_img: "aptible/github-action-demo"
+          app: ${{ github.event_name == 'pull_request' && 'deploy-action-demo-staging' || 'deploy-action-demo' }}
+          environment: public-demos
+          docker_img: ${{ needs.build.outputs.tag }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   build:
+    # This actions publishes a tag based on the branch name (master) on merge to master,
+    # or the commit ID when triggered by Pull Request.
     runs-on: ubuntu-latest
     env:
       image_name: aptible/github-action-demo
@@ -28,8 +30,17 @@ jobs:
     outputs:
       image: ${{ env.image_name }}:${{ steps.publish_image.outputs.tag }}
 
+  test:
+    # Here we test the image as built, before deploying it.
+    # Since this is a simple app, all we can verify is that the nginx configuration is valid
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mock tests
+        run: docker run aptible/github-action-demo nginx -t
+
   deploy:
-    needs: build
+    needs: [build, test]
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -38,10 +49,17 @@ jobs:
       - name: Deploy to Aptible
         uses: aptible/aptible-deploy-action@v5
         with:
+          # We're deploying the image built in the above build job
           type: docker
+          # Aptible credentials for a user with permission to deploy these apps
           username: ${{ vars.APTIBLE_ROBOT_USERNAME }}
           password: ${{ secrets.APTIBLE_ROBOOT_PASSWORD }}
+          # This controls deploying to a staging app for Pull Requests,
+          # and the "production" app when merged to master:
           app: ${{ github.event_name == 'pull_request' && 'deploy-action-demo-staging' || 'deploy-action-demo' }}
+          # Both our staging and "production" app happen to be in the same Aptible environment
           environment: public-demos
+          # Deploy the image and tag published above:
           docker_img: ${{ needs.build.outputs.image }}
+          # Set any app-specific configuration variables here
           config_variables: FORCE_SSL=true 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      image_name: aptible/github-action-demo
     steps:
       - name: Check out code
         uses: actions/checkout@master
@@ -19,12 +21,12 @@ jobs:
         id: publish_image
         uses: elgohr/Publish-Docker-Github-Action@v5
         with:
-          name: aptible/github-action-demo
+          name: ${{ env.image_name }}
           username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
     outputs:
-      image: aptible/github-action-demo:${{ steps.publish_image.outputs.tag }}
+      image: ${{ env.image_name }}:${{ steps.publish_image.outputs.tag }}
 
   deploy:
     needs: build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
         uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: aptible/github-action-demo
-          username: ${{ secrets.DOCKER_USERNAME }}
+          username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
     outputs:
@@ -36,8 +36,8 @@ jobs:
       - name: Deploy to Aptible
         uses: aptible/aptible-deploy-action@fix-versioned-release
         with:
-          username: ${{secrets.APTIBLE_ROBOT_USERNAME}}
-          password: ${{secrets.APTIBLE_ROBOOT_PASSWORD}}
+          username: ${{ vars.APTIBLE_ROBOT_USERNAME }}
+          password: ${{ secrets.APTIBLE_ROBOOT_PASSWORD }}
           app: ${{ github.event_name == 'pull_request' && 'deploy-action-demo-staging' || 'deploy-action-demo' }}
           environment: public-demos
           docker_img: ${{ needs.build.outputs.tag }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,4 +40,4 @@ jobs:
           password: ${{ secrets.APTIBLE_ROBOOT_PASSWORD }}
           app: ${{ github.event_name == 'pull_request' && 'deploy-action-demo-staging' || 'deploy-action-demo' }}
           environment: public-demos
-          docker_img: ${{ needs.build.outputs.tag }}
+          docker_img: ${{ needs.build.outputs.image }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,8 +38,10 @@ jobs:
       - name: Deploy to Aptible
         uses: aptible/aptible-deploy-action@fix-versioned-release
         with:
+          type: docker
           username: ${{ vars.APTIBLE_ROBOT_USERNAME }}
           password: ${{ secrets.APTIBLE_ROBOOT_PASSWORD }}
           app: ${{ github.event_name == 'pull_request' && 'deploy-action-demo-staging' || 'deploy-action-demo' }}
           environment: public-demos
           docker_img: ${{ needs.build.outputs.image }}
+          config_variables: FORCE_SSL=true 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: Deploy to Aptible
-        uses: aptible/aptible-deploy-action@fix-versioned-release
+        uses: aptible/aptible-deploy-action@v5
         with:
           type: docker
           username: ${{ vars.APTIBLE_ROBOT_USERNAME }}


### PR DESCRIPTION
Creates a more realistic example usage of our action, where there's a separate App for "release" (merge to master) vs "staging" (open PR). It also shows how testing can be integrated so you're not deploying an image that may or may not work...

Lots of other maintenance included: 

* Naming and formatting improvements
* Moves the app our of our "chaos" environment to "public-demos".
* Update our user/passwords, and set usernames as variables instead of secrets.
* Bump the elghor/Publish-Docker-Github-Action to an approved/reviewed version
* Updated the link on the project homepage to the new app https://app-90285.on-aptible.com/

